### PR TITLE
API path should start with "/"

### DIFF
--- a/src/notebooks/GF Challenge API Example.ipynb
+++ b/src/notebooks/GF Challenge API Example.ipynb
@@ -38,7 +38,7 @@
     "\n",
     "secret_token = '<API_KEY>' # replace with your API token\n",
     "server = '<SERVER_NAME>'  # of the form 'https://api.[domain].com'\n",
-    "url = server + 'api/v1/questions' # The endpoint to retrieve questions\n",
+    "url = server + '/api/v1/questions' # The endpoint to retrieve questions\n",
     "headers = {'Authorization':'Bearer ' + secret_token}\n",
     "params = {} # More to come on this in a moment\n",
     "\n",


### PR DESCRIPTION
With the "/" missing from the API path you get:

`[Errno 8] nodename nor servname provided, or not known`

(noting that the example of the host name has doesn't have the "/" either)