### PR TITLE
question_id is never passed

### DIFF
--- a/src/notebooks/GF Challenge API Example.ipynb
+++ b/src/notebooks/GF Challenge API Example.ipynb
@@ -350,6 +350,8 @@
     "        section = 'consensus_histories'\n",
     "        params={}\n",
     "        \n",
+    "        if question_id:\n"
+    "            params['question_id'] = str(question_id)\n"
     "        if created_before:\n",
     "            params['created_before'] = created_before.isoformat()\n",
     "        if created_after:\n",


### PR DESCRIPTION
The get_consensus_histories call takes a question_id parameter but fails to pass it to the API.